### PR TITLE
fixed deletion of bad results

### DIFF
--- a/src/controller/Controller.cpp
+++ b/src/controller/Controller.cpp
@@ -98,10 +98,12 @@ Controller::Controller(const std::filesystem::path &configPath, bool isStub) {
             scenarios[i] = runnerConfig.at("scenarios").at(i).get<std::string>();
         }
 
-        std::string dir = runnerConfig.at("configDirectory").get<std::string>();
+        std::filesystem::path dir = runnerConfig.at("configDirectory").get<std::string>();
+        std::filesystem::remove_all(dir.append("optResults"));
         runner = std::unique_ptr<SimulationRunner>(new PlexeSimulationRunner(nrThreads, repeat, scenarios,
-                                                                             ConfigEditor(dir, runnerConfig.at(
-                                                                                     "controller"))));
+                                                                             ConfigEditor(dir.parent_path(),
+                                                                                          runnerConfig.at(
+                                                                                                  "controller"))));
     } else {
         throw std::runtime_error("SimulationRunner not found: " + run);
     }

--- a/src/controller/ValueMap.cpp
+++ b/src/controller/ValueMap.cpp
@@ -121,12 +121,16 @@ bool ValueMap::isTopValue(const parameterCombination &cords) {
         if (entry.first.size() != cords.size()) {
             continue;
         }
+        bool equal = true;
         for (int i = 0; i < entry.first.size(); ++i) {
             if (entry.first[i]->getVal() != cords[i]->getVal()) {
-                continue;
+                equal = false;
+                break;
             }
         }
-        return true;
+        if (equal) {
+            return true;
+        }
     }
     return false;
 }


### PR DESCRIPTION
Old results that are not the n best results weren't deleted which slowed down constant_headway evaluation. Also at the start of every optimization the old result directory is cleared.